### PR TITLE
Fixes Mobile Nav Bug

### DIFF
--- a/common/menu.php
+++ b/common/menu.php
@@ -3,7 +3,7 @@
         <nav class="navbar">
             <div class="container">
                 <div class="navbar-header">
-                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-collapse" aria-expanded="false">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#nav-collapse" aria-expanded="false" ontouchend="this.style.top='0px';this.style.boxShadow='0px 0px 0px 0px #000000';this.style.backgroundColor='inherit';">
                         <span class="sr-only">Toggle navigation</span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>


### PR DESCRIPTION
Fixed the problem where the mobile nav menu bar wouldn’t un-hover on
mobile. I feel like this is a flaw in the CSS standard that the hover
pseudo-class isn’t automatically removed ontouchend, resolved by
overriding CSS with inline JS

This closes #38